### PR TITLE
ci: add style job which ensures our go project is formatted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,18 @@ jobs:
 
       - name: Run tests
         run: go test -cover ./...
+
+  style:
+    name: Style
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.0'
+      - name: Check formatting
+        run: test -z $(go fmt ./...)


### PR DESCRIPTION
ci: Add a separate job (job_id == "style") that checks whether our Go project is formatted correctly. Uses bash's test command to check if go fmt ./... returns anything. 